### PR TITLE
[Fix] 이슈 관련 버그들 해결 완료

### DIFF
--- a/Aster_Game/Assets/Scenes/networkSample.unity
+++ b/Aster_Game/Assets/Scenes/networkSample.unity
@@ -295,7 +295,7 @@ RectTransform:
   - {fileID: 849575040}
   - {fileID: 1738240886}
   m_Father: {fileID: 1411873772}
-  m_RootOrder: 1
+  m_RootOrder: 2
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 1, y: 1}
@@ -494,7 +494,7 @@ RectTransform:
   - {fileID: 1768232111}
   - {fileID: 411007374}
   m_Father: {fileID: 1411873772}
-  m_RootOrder: 2
+  m_RootOrder: 1
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 0.5}
   m_AnchorMax: {x: 0.5, y: 0.5}
@@ -1556,7 +1556,7 @@ RectTransform:
   - {fileID: 1510819913}
   - {fileID: 1898831459}
   m_Father: {fileID: 1411873772}
-  m_RootOrder: 0
+  m_RootOrder: 3
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 1, y: 1}
@@ -3790,7 +3790,7 @@ RectTransform:
   - {fileID: 966479776}
   - {fileID: 326085057}
   m_Father: {fileID: 1411873772}
-  m_RootOrder: 3
+  m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 0.5}
   m_AnchorMax: {x: 0.5, y: 0.5}
@@ -4993,10 +4993,10 @@ RectTransform:
   m_LocalScale: {x: 0, y: 0, z: 0}
   m_ConstrainProportionsScale: 0
   m_Children:
-  - {fileID: 334746006}
-  - {fileID: 35762237}
-  - {fileID: 81709055}
   - {fileID: 1076062419}
+  - {fileID: 81709055}
+  - {fileID: 35762237}
+  - {fileID: 334746006}
   - {fileID: 2022766902}
   m_Father: {fileID: 0}
   m_RootOrder: 8

--- a/Aster_Game/Assets/Script/Network/Lobby/LobbySingleton.cs
+++ b/Aster_Game/Assets/Script/Network/Lobby/LobbySingleton.cs
@@ -141,6 +141,10 @@ namespace AG.Network.AGLobby
             } 
             catch (LobbyServiceException e) 
             {
+                if(e.Reason == LobbyExceptionReason.NoOpenLobbies)
+                {
+                    Debug.Log($"No Open Lobbies");
+                }
                 Debug.Log(e);
             }
         }
@@ -254,7 +258,7 @@ namespace AG.Network.AGLobby
 
         private async void MigrateHost()
         {
-            if(!IsLobbyhost())  return;
+            if(!IsLobbyhost() || joinedLobby.Players.Count <= 1)  return;
             try
             {
                 joinedLobby = await Lobbies.Instance.UpdateLobbyAsync(joinedLobby.Id, new UpdateLobbyOptions{

--- a/Aster_Game/Assets/Script/Network/Lobby/LobbySingleton.cs
+++ b/Aster_Game/Assets/Script/Network/Lobby/LobbySingleton.cs
@@ -134,10 +134,8 @@ namespace AG.Network.AGLobby
         public async void QuickMatch()
         {
             try {
-                QuickJoinLobbyOptions options = new QuickJoinLobbyOptions();
-
-                Lobby lobby = await LobbyService.Instance.QuickJoinLobbyAsync(options);
-                joinedLobby = lobby;
+                QuickJoinLobbyOptions options = new QuickJoinLobbyOptions{ Player = GetPlayer() };
+                joinedLobby = await LobbyService.Instance.QuickJoinLobbyAsync(options);
 
                 joinLobbyEvent?.Invoke(joinedLobby);
             } 

--- a/Aster_Game/Assets/Script/UI/LobbyUI/JoinedLobbyMenu.cs
+++ b/Aster_Game/Assets/Script/UI/LobbyUI/JoinedLobbyMenu.cs
@@ -59,6 +59,14 @@ namespace AG.UI.LobbyUI
                 this.transform.parent.gameObject.SetActive(false); 
             };
 
+            LobbySingleton.instance.kickedFromLobbyEvent += () => {
+                this.gameObject.SetActive(false);
+            };
+
+            LobbySingleton.instance.leaveLobbyEvent += () => {
+                this.gameObject.SetActive(false);
+            };
+
             this.gameObject.SetActive(false);
         }
 

--- a/Aster_Game/Assets/Script/UI/LobbyUI/LobbyPlayerInfomationUI.cs
+++ b/Aster_Game/Assets/Script/UI/LobbyUI/LobbyPlayerInfomationUI.cs
@@ -28,7 +28,6 @@ namespace AG.UI.LobbyUI
         public void SetPlayerInfo(Player player)
         {
             this.player = player;
-            // TODO : Quick match 사용시 오류 나옴
             playerNameText.text = player.Data[NetworkConstants.PLAYERNAME_KEY].Value;
         }
 

--- a/Aster_Game/Assets/Script/UI/LobbyUI/LobbySetupMenu.cs
+++ b/Aster_Game/Assets/Script/UI/LobbyUI/LobbySetupMenu.cs
@@ -40,6 +40,14 @@ namespace AG.UI.LobbyUI
                 LobbySingleton.instance.QuickMatch();
             });
 
+            LobbySingleton.instance.kickedFromLobbyEvent += () => { 
+                this.gameObject.SetActive(true);
+            };
+
+            LobbySingleton.instance.leaveLobbyEvent += () => {
+                this.gameObject.SetActive(true);
+            };
+
             createLobbyMenu.SetActive(false);
             this.gameObject.SetActive(false);
         }


### PR DESCRIPTION
## 퀵 매치 오류
![error](https://user-images.githubusercontent.com/68003176/214829442-99fa1f81-5651-4692-943a-2c37963277b7.PNG)

일단 이전 오류를 조금 자세히 풀어보면 **"퀵 매치시 플레이어 이름을 불러올 때 오류가 발생"**하는 것이었습니다. 이와 연관되어서 로그를 한번 찍어보니 일단 AuthenticationService의 아이디는 잘 찍히고 Player.Data를 찾지 못하는 오류였습니다.
잘 보니 다른 로비 접근 메소드들의 경우 player 인자로 LobbySingleton.GetPlayer()를 넘겨주게 되는데 퀵 매치의 경우 이 작업이 없어서 그랬습니다. 때문에 플레이어를 인자로 넣어주니 이름 표기가 잘 되었습니다.

```cs
public async void QuickMatch()
{
    try {
        QuickJoinLobbyOptions options = new QuickJoinLobbyOptions{ Player = GetPlayer() };
        joinedLobby = await LobbyService.Instance.QuickJoinLobbyAsync(options);

        joinLobbyEvent?.Invoke(joinedLobby);
    } 
//...
```
<br><br>
## 플레이어 강퇴

일단 이전 로직에서 개선을 해서 
- 로비 방장이 아니면 바로 return
- 로비 방장의 아이디라면(자가 킥) 바로 return
- 위 경우 모두 아니라면 (방장이 누른 것이고 방장 자신이 아니면) 유저 강퇴

추가로 강퇴 당했을 시 로직도 개선을 했습니다.
이전에는 로비 정보를 주기적으로 업데이트 하면서 `로비 참가 event  호출 -> 킥 되었는지 검사 -> 게임 시작했는지 검사` 를 했습니다. 이 로직이 강퇴 되었을 때 문제가 되었는데 강퇴시 `GetLobbyAsync() -> 강퇴 당해서 로비가 없음 -> 없는 로비를 통해 이벤트 호출` 이 되어서 오류가 나왔던 것입니다.
이를 일단 GetLobbyAsync를 한 뒤 만일 여기에 본인이 없다(강퇴 당함) 이라면 강퇴 이벤트 호출 뒤 바로 return 을 해서 오류를 피했습니다.

```cs
var lobby = await LobbyService.Instance.GetLobbyAsync(joinedLobby.Id);
joinedLobby = lobby;

if(!IsPlayerInLobby())
{
   //... 강퇴 이벤트 시작
}
if(joinedLobby.Data[NetworkConstants.GAMESTART_KEY].Value != NetworkConstants.GAMESTART_KEY_DEFAULT)
{
    //... 게임 시작
}
//... 전부 아니라면 그냥 로비 정보 업데이트
joinLobbyEvent?.Invoke(joinedLobby);
```
<br><br>

## 로비 떠나도 아무 일 없던 오류

강퇴 로직을 고치면서 함께 고쳐진 문제입니다. 로비를 떠난 뒤 호스트를 로비의 바로 다음(2번째 참가자가 있다면) 으로 넘겨준 뒤 Leave 를 하게 됩니다.